### PR TITLE
Alt child injector interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,18 @@ You can create sub-injectors by passing an existing injector to the
 `newInjector` function:
 
 ```typescript
-const parent = newInjector([]);
+const parent = newInjector();
 const child = newInjector([], parent);
 ```
+
+Alternatively, you can use the `child` function on an existing injector:
+
+```typescript
+const parent = newInjector();
+const child = parent.child();
+```
+
+Pass `provide`s to this function to configure the new injector.
 
 Calling `.get` on a sub-injector will build and store new objects in the
 parent-most injector by default; however, when building with a sub-injector, the

--- a/deno.json
+++ b/deno.json
@@ -1,9 +1,6 @@
 {
     "name": "@cjc/injector",
     "version": "0.5.0",
-    "tasks": {
-        "dev": "deno run --watch main.ts"
-    },
     "fmt": {
         "indentWidth": 4,
         "exclude": [
@@ -25,7 +22,7 @@
             "./src/**/*.ts",
             "./index.ts"
         ],
-        "exclude": ["./edu", "./src/test/*", "./src/dfs/test.ts"]
+        "exclude": ["./edu", "./src/test/*"]
     },
     "exports": "./index.ts"
 }

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
     "name": "@cjc/injector",
-    "version": "0.4.1",
+    "version": "0.5.0",
     "tasks": {
         "dev": "deno run --watch main.ts"
     },

--- a/src/injector.ts
+++ b/src/injector.ts
@@ -144,6 +144,15 @@ class Injector {
             Injector.context = prevInjector;
         }
     }
+
+    /**
+     * Creates a new Injector as a child to `this` Injector
+     * @param provides (optional) provide configuration for the new Injector
+     * @returns Injector
+     */
+    public child(provides: Provide[] = []): Injector {
+        return new Injector(provides, this);
+    }
     // PRIVATE ///////////////////////////////////////////////////////////////
     /**
      * Copies the minimum necessary information from a Provide into this injector,
@@ -156,7 +165,6 @@ class Injector {
             holder: this,
         });
     }
-
     /**
      * The actual `get` implementation; assumes an active injection context
      */

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -456,3 +456,20 @@ Deno.test("dependency recording", async (test) => {
         assert(caught, "should have thrown error");
     });
 });
+
+Deno.test("child injector function", () => {
+    class A {
+        public b = inject(B);
+    }
+    class B {}
+    class A_ extends A {}
+    class B_ extends B {}
+    const p = newInjector([provide(A).useExisting(A_)]);
+    const c = p.child([provide(B).useExisting(B_)]);
+    const a = c.get(A);
+    assert(a instanceof A_, "should incorporate parent injector configuration");
+    assert(
+        a.b instanceof B_,
+        "should incorporate child injector configuration",
+    );
+});


### PR DESCRIPTION
Creates a new method for generating child injectors, directly on the injector class itself. (Might present a slightly more pleasant interface).


Not sure on the name of the function. Current version is "branch()", but other possibilities could be `child()`, `sub()`, or `spawn()`