### PR TITLE
implement a multi inject system with minimal impact on the core injector design

### DIFF
--- a/src/injector.ts
+++ b/src/injector.ts
@@ -1,4 +1,4 @@
-import type { Ctor, InjectKey } from "./types/injectkey.ts";
+import type { Ctor, InjectKey, ProviderRequired } from "./types/injectkey.ts";
 import type { Provide } from "./types/provide.ts";
 import {
     InjectError,
@@ -122,6 +122,7 @@ export class Injector {
             }
         };
     }
+
     /**
      * @returns the childmost injector (the injector of highest rank)
      */
@@ -139,7 +140,19 @@ export class Injector {
     private readonly rank: number;
     // PUBLIC ////////////////////////////////////////////////////////////////
     constructor(provides: Provide[] = [], private parent?: Injector) {
-        provides.map((p) => this.setLocalProvide(p));
+        const multiProvides = new Map<ProviderRequired, Provide[]>();
+        for (const provide of provides) {
+            if (!provide.multi) {
+                this.setLocalProvide(provide);
+                continue;
+            }
+
+            if (!multiProvides.has(provide.key)) {
+                multiProvides.set(provide.key, []);
+            }
+            multiProvides.get(provide.key)?.push(provide);
+        }
+        this.createMultiProvides(multiProvides);
         this.rank = this.parent ? this.parent.rank + 1 : 0;
     }
 
@@ -187,11 +200,33 @@ export class Injector {
             holder: this,
         });
     }
+
+    private createMultiProvides(
+        multiProvides: Map<ProviderRequired, Provide[]>,
+    ): void {
+        for (const [multiKey, multiProvideList] of multiProvides) {
+            this.setLocalProvide({
+                key: multiKey,
+                factory: () => {
+                    const parentArray = this.parent?.getInContext(
+                        multiKey,
+                        { useInjectionStack: false }, // prevents false cycle detection
+                    ) as unknown[] ??
+                        [];
+                    const array = multiProvideList.map((p) => p.factory());
+                    return parentArray.concat(...array);
+                },
+            });
+        }
+    }
     /**
      * The actual `get` implementation; assumes an active injection context
      */
-    private getInContext<T>(key: InjectKey<T>): T {
-        InjectionStack.push(key);
+    private getInContext<T>(
+        key: InjectKey<T>,
+        { useInjectionStack = true }: { useInjectionStack?: boolean } = {},
+    ): T {
+        useInjectionStack && InjectionStack.push(key);
         try {
             const built = this.cache.get(key) ?? this.getBuilt(key);
             if (Injector.buildingProvide) {
@@ -206,7 +241,7 @@ export class Injector {
             // cast since the key/value always match types when set.
             return built.value as T;
         } finally {
-            InjectionStack.pop();
+            useInjectionStack && InjectionStack.pop();
         }
     }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,11 @@
-import type { ImplicitlyAvailable, InjectKey } from "./types/injectkey.ts";
+import type {
+    ImplicitlyAvailable,
+    InjectKey,
+    ProviderRequired,
+} from "./types/injectkey.ts";
 import { internalInject } from "./inject.ts";
 import type { Provide } from "./types/provide.ts";
+import { ProvideKey } from "./providekey.ts";
 
 /**
  * Quality of life function for generating `Provide` objects to configure an
@@ -24,6 +29,21 @@ import type { Provide } from "./types/provide.ts";
  */
 export function provide<T>(key: InjectKey<T>): Provider<T> {
     return new Provider(key);
+}
+
+export function provideMulti<T>(key: ProvideKey<T[]>): Provider<T> {
+    const provider = new Provider(key as ProvideKey<T>);
+    const handler = {
+        get: (obj: Provider<T>, prop: keyof Provider<T>) => {
+            return function (arg: any) {
+                return {
+                    ...obj[prop](arg),
+                    multi: true,
+                };
+            };
+        },
+    };
+    return new Proxy(provider, handler);
 }
 
 /**

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -10,7 +10,7 @@ import {
 } from "../injectioncontext.ts";
 import { newInjector } from "../injector.ts";
 import { key } from "../providekey.ts";
-import { explicitly, provide } from "../provider.ts";
+import { explicitly, provide, provideMulti } from "../provider.ts";
 import { NoImplicitInject } from "../symbols/noimplicitinject.ts";
 import { assert } from "./lib.ts";
 import { DummyFactory } from "../symbols/dummyfactory.ts";
@@ -648,4 +648,63 @@ Deno.test("allow chains of useExisting on abstract classes", () => {
         caught = true;
     }
     assert(!caught, "should not have thrown an error");
+});
+
+Deno.test("multi inject", async (test) => {
+    await test.step("basic multi provide and inject", () => {
+        const MultiKey = key<string[]>("MultiKey");
+        const injector = newInjector([
+            provideMulti(MultiKey).useValue("a"),
+            provideMulti(MultiKey).useValue("b"),
+            provideMulti(MultiKey).useValue("c"),
+        ]);
+        const values = injector.get(MultiKey);
+        assert(
+            values.length === 3 &&
+                values.includes("a") &&
+                values.includes("b") &&
+                values.includes("c"),
+            "should correctly inject multiple values",
+        );
+    });
+    await test.step("multi provides spread through hierarchy", () => {
+        const MultiKey = key<string[]>("MultiKey");
+        const gp = newInjector([
+            provideMulti(MultiKey).useValue("a"),
+        ]);
+        const p = newInjector([
+            provideMulti(MultiKey).useValue("b"),
+            provideMulti(MultiKey).useValue("c"),
+        ], gp);
+        const c = newInjector([
+            provideMulti(MultiKey).useValue("d"),
+        ], p);
+        const values = c.get(MultiKey);
+        assert(
+            values.length === 4 &&
+                values.includes("a") &&
+                values.includes("b") &&
+                values.includes("c") &&
+                values.includes("d"),
+            "should correctly inject multiple values from across the injector hierarchy",
+        );
+    });
+    await test.step("multi provides honor different kinds of provides", () => {
+        const MultiKey = key<string[]>("MultiKey");
+        const CKey = key<string>("CKey");
+        const injector = newInjector([
+            provideMulti(MultiKey).useValue("a"),
+            provideMulti(MultiKey).use(() => "b"),
+            provideMulti(MultiKey).useExisting(CKey),
+            provide(CKey).useValue("c"),
+        ]);
+        const values = injector.get(MultiKey);
+        assert(
+            values.length === 3 &&
+                values.includes("a") &&
+                values.includes("b") &&
+                values.includes("c"),
+            "should correctly inject multiple values from different kinds of provides",
+        );
+    });
 });

--- a/src/types/provide.ts
+++ b/src/types/provide.ts
@@ -1,6 +1,16 @@
+import type { ProvideKey } from "../providekey.ts";
 import type { InjectKey } from "./injectkey.ts";
 
-export interface Provide<T = unknown> {
+export interface BaseProvide<T = unknown> {
     key: InjectKey<T>;
     factory: () => T;
+    multi?: never;
 }
+
+export interface MultiProvide<T = unknown> {
+    key: ProvideKey<T[]>;
+    factory: () => T; // the injector will aggregate
+    multi: true;
+}
+
+export type Provide<T = unknown> = BaseProvide<T> | MultiProvide<T>;


### PR DESCRIPTION
An approach to multi inject that doesn't require complex branching logic throughout the injector--just a little extra type magic and syntax, and a simple step in the injector constructor to aggregate provides